### PR TITLE
feat: share projects with other bundler REPLs

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { Clock, Download, RotateCcw, Share2 } from "lucide-react";
+import { Clock, Copy, Download, ExternalLink, RotateCcw, Share2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import Github from "@/components/icon/Github";
@@ -19,6 +19,14 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   Select,
   SelectContent,
   SelectGroup,
@@ -30,7 +38,13 @@ import {
 } from "@/components/ui/select";
 import useBundle from "@/hooks/use-bundle";
 import { useDownloadProject } from "@/hooks/use-download";
-import { getShareUrl, type ShareData } from "@/lib/share";
+import {
+  getEsbuildReplUrl,
+  getRollupReplUrl,
+  getShareUrl,
+  getWebpackReplUrl,
+  type ShareData,
+} from "@/lib/share";
 import {
   bundleResultAtom,
   createEditorSourceFiles,
@@ -71,6 +85,12 @@ function getVersionDisplay(version: string) {
     fullLabel: `v${version}`,
   };
 }
+
+const replLabels = {
+  webpack: "webpack REPL",
+  esbuild: "esbuild REPL",
+  rollup: "Rollup REPL",
+} as const;
 
 export default function Header() {
   const iconButtonClassName =
@@ -116,6 +136,25 @@ export default function Header() {
     } catch (error) {
       console.error("Failed to share:", error);
       toast.error("Failed to copy share link");
+    }
+  };
+
+  const handleOpenInRepl = (target: keyof typeof replLabels) => {
+    try {
+      const shareData: ShareData = {
+        rspackVersion,
+        inputFiles,
+      };
+      const replUrl = {
+        webpack: getWebpackReplUrl,
+        esbuild: getEsbuildReplUrl,
+        rollup: getRollupReplUrl,
+      }[target](shareData);
+
+      window.open(replUrl, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      console.error(`Failed to open ${target} REPL:`, error);
+      toast.error(`Failed to open ${target} REPL`);
     }
   };
 
@@ -239,17 +278,35 @@ export default function Header() {
               <Download className="h-3.5 w-3.5" />
               <span className="sr-only">Download</span>
             </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={iconButtonClassName}
-              onClick={handleShare}
-              title="Share current configuration"
-              aria-label="Share current configuration"
-            >
-              <Share2 className="h-3.5 w-3.5" />
-              <span className="sr-only">Share</span>
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={iconButtonClassName}
+                  title="Share or open in another bundler"
+                  aria-label="Share or open in another bundler"
+                >
+                  <Share2 className="h-3.5 w-3.5" />
+                  <span className="sr-only">Share</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-52">
+                <DropdownMenuLabel>Share</DropdownMenuLabel>
+                <DropdownMenuItem onClick={() => void handleShare()}>
+                  <Copy className="h-3.5 w-3.5" />
+                  Copy Rspack link
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel>Open project in</DropdownMenuLabel>
+                {(["webpack", "esbuild", "rollup"] as const).map((target) => (
+                  <DropdownMenuItem key={target} onClick={() => handleOpenInRepl(target)}>
+                    <span>{replLabels[target]}</span>
+                    <ExternalLink className="ml-auto h-3.5 w-3.5 text-muted-foreground" />
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,9 +1,88 @@
 import type { SourceFile } from "@/store/bundler";
+import { RSPACK_CONFIG } from "@/store/common";
+
+const WEBPACK_REPL_URL = "https://webpack-repl.vercel.app/";
+const ESBUILD_REPL_URL = "https://esbuild.github.io/try/";
+const ROLLUP_REPL_URL = "https://rollupjs.org/repl/";
+
+const SCRIPT_FILE_PATTERN = /\.[cm]?[jt]sx?$/i;
+const CONVENTIONAL_ENTRY_PATTERNS = [
+  /^src\/main\.[cm]?[jt]sx?$/i,
+  /^src\/index\.[cm]?[jt]sx?$/i,
+  /^main\.[cm]?[jt]sx?$/i,
+  /^index\.[cm]?[jt]sx?$/i,
+  /^entry\.[cm]?[jt]sx?$/i,
+];
 
 export interface ShareData {
   rspackVersion: string;
   inputFiles: SourceFile[];
 }
+
+const encodeBase64 = (value: string): string => {
+  const utf8Bytes = new TextEncoder().encode(value);
+  let binaryString = "";
+  for (const byte of utf8Bytes) {
+    binaryString += String.fromCharCode(byte);
+  }
+  return btoa(binaryString);
+};
+
+const normalizeReplFilename = (filename: string): string =>
+  filename
+    .replace(/\\/g, "/")
+    .replace(/^(?:\.\/)+/, "")
+    .replace(/^\/+/, "");
+
+const withoutRspackConfig = (inputFiles: SourceFile[]): SourceFile[] =>
+  inputFiles.filter(({ filename }) => normalizeReplFilename(filename) !== RSPACK_CONFIG);
+
+const getStaticRspackEntryFilenames = (inputFiles: SourceFile[]): Set<string> => {
+  const config = inputFiles.find(
+    ({ filename }) => normalizeReplFilename(filename) === RSPACK_CONFIG,
+  );
+  if (!config) {
+    return new Set();
+  }
+
+  const entryValue = config.text.match(/\bentry\s*:\s*(["'`])([^"'`]+)\1/);
+  const entryCollection = config.text.match(/\bentry\s*:\s*(?:\{([\s\S]*?)\}|\[([\s\S]*?)\])/);
+  const entryCollectionText = entryCollection?.[1] ?? entryCollection?.[2];
+  const entryFilenames = entryValue
+    ? [entryValue[2]]
+    : Array.from(entryCollectionText?.matchAll(/(["'`])([^"'`]+)\1/g) ?? [], (match) =>
+        normalizeReplFilename(match[2]),
+      );
+  const availableFilenames = new Set(
+    inputFiles.map(({ filename }) => normalizeReplFilename(filename)),
+  );
+
+  return new Set(
+    entryFilenames
+      .map((filename) => normalizeReplFilename(filename))
+      .filter((filename) => SCRIPT_FILE_PATTERN.test(filename) && availableFilenames.has(filename)),
+  );
+};
+
+const getReplEntryFilenames = (inputFiles: SourceFile[]): Set<string> => {
+  const staticEntries = getStaticRspackEntryFilenames(inputFiles);
+  if (staticEntries.size > 0) {
+    return staticEntries;
+  }
+
+  const scriptFilenames = inputFiles
+    .map(({ filename }) => normalizeReplFilename(filename))
+    .filter((filename) => filename !== RSPACK_CONFIG && SCRIPT_FILE_PATTERN.test(filename));
+
+  for (const pattern of CONVENTIONAL_ENTRY_PATTERNS) {
+    const entryFilename = scriptFilenames.find((filename) => pattern.test(filename));
+    if (entryFilename) {
+      return new Set([entryFilename]);
+    }
+  }
+
+  return new Set(scriptFilenames.slice(0, 1));
+};
 
 // Share functionality
 // Use Unicode-safe base64 encoding to support Chinese and other non-Latin1 characters
@@ -12,10 +91,7 @@ export const serializeShareData = (data: ShareData): string => {
     rspackVersion: data.rspackVersion,
     inputFiles: data.inputFiles.map(({ filename, text }) => ({ filename, text })),
   });
-  // Convert string to UTF-8 bytes, then to base64
-  const utf8Bytes = new TextEncoder().encode(jsonString);
-  const binaryString = Array.from(utf8Bytes, (byte) => String.fromCharCode(byte)).join("");
-  return btoa(binaryString);
+  return encodeBase64(jsonString);
 };
 
 export const deserializeShareData = (base64: string): ShareData | null => {
@@ -44,4 +120,47 @@ export const deserializeShareData = (base64: string): ShareData | null => {
 export const getShareUrl = (data: ShareData): string => {
   const base64 = serializeShareData(data);
   return `${window.location.origin}${window.location.pathname}#${base64}`;
+};
+
+export const getWebpackReplUrl = (data: ShareData): string =>
+  `${WEBPACK_REPL_URL}#${serializeShareData(data)}`;
+
+export const getEsbuildReplUrl = (data: ShareData): string => {
+  const entryFilenames = getReplEntryFilenames(data.inputFiles);
+  const payload = ["b", "latest", "--bundle\n--format=esm\n--outdir=out"];
+
+  for (const { filename, text } of withoutRspackConfig(data.inputFiles)) {
+    const replFilename = normalizeReplFilename(filename);
+    payload.push(entryFilenames.has(replFilename) ? "e" : "", replFilename, text);
+  }
+
+  return `${ESBUILD_REPL_URL}#${encodeBase64(payload.join("\0")).replace(/=+$/, "")}`;
+};
+
+export const getRollupReplUrl = (data: ShareData): string => {
+  const entryFilenames = getReplEntryFilenames(data.inputFiles);
+  const modules = withoutRspackConfig(data.inputFiles).map(({ filename, text }) => {
+    const replFilename = normalizeReplFilename(filename);
+    return {
+      code: text,
+      isEntry: entryFilenames.has(replFilename),
+      name: replFilename,
+    };
+  });
+
+  // The Rollup REPL always uses the first module as an entry module.
+  modules.sort((a, b) => Number(b.isEntry) - Number(a.isEntry));
+
+  const json = JSON.stringify({
+    example: "",
+    modules,
+    options: {},
+  });
+  const asciiJson = json.replace(
+    /[\u0080-\uFFFF]/g,
+    (character) => `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+  const shareable = btoa(asciiJson).replace(/\//g, "_").replace(/\+/g, "-");
+
+  return `${ROLLUP_REPL_URL}?shareable=${shareable}`;
 };


### PR DESCRIPTION
## Summary

- replace the share action with a menu that copies the Rspack link or opens the project in webpack, esbuild, and Rollup REPLs
- encode each destination native share format while preserving multiple files, Unicode content, and static entry points
- omit rspack.config.js for esbuild and Rollup, and open external REPLs in a new tab

## Testing

- pnpm exec tsc --noEmit --ignoreDeprecations 6.0
- pnpm format:check
- pnpm lint:check
- pnpm build
- browser-verified multi-file, multi-entry, and Unicode transfers in webpack, esbuild, and Rollup REPLs