### PR TITLE
feat: refine playground workspace UI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Check lint and formatting
         run: pnpm run check
+
+      - name: Run tests
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "rs fmt",
     "lint": "rs lint",
     "prepare": "rs hooks",
-    "preview": "rs preview"
+    "preview": "rs preview",
+    "test": "node --experimental-strip-types --test tests/*.test.mjs"
   },
   "dependencies": {
     "@monaco-editor/react": "4.7.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,10 @@ const App = () => {
   );
 
   return (
-    <ThemeProvider defaultTheme="system">
-      <div className="relative h-screen flex flex-col">
+    <ThemeProvider defaultTheme="dark">
+      <div className="relative flex h-dvh min-h-0 flex-col">
         <Header />
-        <main className="flex-1 overflow-hidden">
+        <main className="min-h-0 flex-1 overflow-hidden px-2 pb-2 sm:px-4 sm:pb-4">
           <Editor />
         </main>
       </div>

--- a/src/components/Dependencies/ChunkGraphCanvas.tsx
+++ b/src/components/Dependencies/ChunkGraphCanvas.tsx
@@ -2,9 +2,11 @@ import type { PointerEvent as ReactPointerEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { RspackChunkGroupInfo, RspackChunkInfo } from "@/lib/bundle/dependency";
 import { cn } from "@/lib/utils";
+import GraphControls, { useGraphRenderScale } from "./GraphControls";
 import {
   buildCurvedPath,
   clampScale,
+  getGraphFrame,
   getSvgPoint,
   labelFromGraphText,
   projectPointToRect,
@@ -479,6 +481,22 @@ export default function ChunkGraphCanvas({
     };
   }, []);
 
+  const frame = useMemo(
+    () =>
+      getGraphFrame(
+        graph.nodes.map((node) => ({
+          position: layout.positions[node.id] ?? { x: 0, y: 0 },
+          width: node.width,
+          height: node.height,
+        })),
+      ),
+    [graph.nodes, layout.positions],
+  );
+
+  const renderScale = useGraphRenderScale(svgRef, frame, view.scale);
+  const compact = renderScale < 0.7;
+  const labelSize = Math.min(24, 12 / renderScale);
+
   const positionedNodes = useMemo(() => {
     return graph.nodes.map((node) => ({
       ...node,
@@ -591,11 +609,19 @@ export default function ChunkGraphCanvas({
   };
 
   const updateScale = (factor: number) => {
-    setView((current) => ({
-      scale: clampScale(current.scale * factor),
-      panX: current.panX,
-      panY: current.panY,
-    }));
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const center = getSvgPoint(svg, rect.x + rect.width / 2, rect.y + rect.height / 2);
+    if (!center) return;
+    setView((current) => {
+      const scale = clampScale(current.scale * factor);
+      return {
+        scale,
+        panX: center.x - ((center.x - current.panX) * scale) / current.scale,
+        panY: center.y - ((center.y - current.panY) * scale) / current.scale,
+      };
+    });
   };
 
   if (graph.nodes.length === 0) {
@@ -612,54 +638,28 @@ export default function ChunkGraphCanvas({
   }
 
   return (
-    <div className={cn("rounded-lg border bg-background/70", className)}>
-      <div className="flex items-center justify-between border-b px-3 py-2">
-        <div className="text-sm font-medium">Chunk Graph</div>
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => updateScale(1.15)}
-            className="rounded-md border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent"
-          >
-            +
-          </button>
-          <button
-            type="button"
-            onClick={() => updateScale(0.87)}
-            className="rounded-md border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent"
-          >
-            -
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setView({ panX: 0, panY: 0, scale: 1 });
-              setNodeOverrides({});
-            }}
-            className="rounded-md border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent"
-          >
-            Reset
-          </button>
-        </div>
+    <div className={cn("overflow-hidden rounded-md border bg-card", className)}>
+      <div className="flex h-11 items-center justify-between gap-2 border-b bg-muted/40 px-3">
+        <h3 className="text-[11px] font-medium">Chunk groups</h3>
+        <GraphControls
+          scale={view.scale}
+          onZoom={updateScale}
+          onReset={() => {
+            setView({ panX: 0, panY: 0, scale: 1 });
+            setNodeOverrides({});
+          }}
+        />
       </div>
 
-      <div className="h-[420px] overflow-hidden">
+      <div className="graph-stage h-[360px] overflow-hidden">
         <svg
           ref={svgRef}
-          viewBox={`0 0 ${layout.width} ${layout.height}`}
-          className="h-full w-full touch-none select-none overscroll-none"
+          viewBox={`${frame.x} ${frame.y} ${frame.width} ${frame.height}`}
+          className="h-full w-full touch-none select-none overscroll-none cursor-grab active:cursor-grabbing"
+          aria-label="Chunk groups interactive canvas"
           onPointerDown={handleCanvasPointerDown}
         >
           <defs>
-            <pattern id="chunk-graph-grid" width="32" height="32" patternUnits="userSpaceOnUse">
-              <path
-                d="M 32 0 L 0 0 0 32"
-                fill="none"
-                stroke="currentColor"
-                strokeOpacity="0.08"
-                strokeWidth="1"
-              />
-            </pattern>
             <marker
               id="chunk-graph-arrow"
               markerWidth="6"
@@ -669,17 +669,16 @@ export default function ChunkGraphCanvas({
               orient="auto"
               markerUnits="userSpaceOnUse"
             >
-              <path d="M 0 0 L 6 3 L 0 6 z" fill="#3b82f6" />
+              <path d="M 0 0 L 6 3 L 0 6 z" fill="var(--graph-edge)" />
             </marker>
           </defs>
 
           <rect
-            x="0"
-            y="0"
-            width={layout.width}
-            height={layout.height}
-            fill="url(#chunk-graph-grid)"
-            className="text-foreground"
+            x={frame.x}
+            y={frame.y}
+            width={frame.width}
+            height={frame.height}
+            fill="transparent"
             onPointerDown={handleCanvasPointerDown}
           />
 
@@ -694,14 +693,14 @@ export default function ChunkGraphCanvas({
                 target.position,
                 source.width,
                 source.height,
-                6,
+                -2,
               );
               const end = projectPointToRect(
                 target.position,
                 source.position,
                 target.width,
                 target.height,
-                12,
+                -8,
               );
               const isCurrent =
                 currentGroupIdSet.has(edge.sourceId) || currentGroupIdSet.has(edge.targetId);
@@ -711,9 +710,9 @@ export default function ChunkGraphCanvas({
                   key={edge.id}
                   d={buildCurvedPath(start, end)}
                   fill="none"
-                  stroke="rgba(59, 130, 246, 0.45)"
+                  stroke="var(--graph-edge)"
                   strokeWidth={isCurrent ? 2.6 : 1.6}
-                  strokeOpacity={isCurrent ? 0.95 : 0.45}
+                  strokeOpacity={isCurrent ? 1 : 0.8}
                   markerEnd="url(#chunk-graph-arrow)"
                   strokeLinecap="round"
                   strokeLinejoin="round"
@@ -729,22 +728,19 @@ export default function ChunkGraphCanvas({
                   key={node.id}
                   transform={`translate(${node.position.x} ${node.position.y})`}
                   onPointerDown={(event) => handleGroupPointerDown(event, node.id)}
-                  className="cursor-grab active:cursor-grabbing"
+                  className="graph-node cursor-grab active:cursor-grabbing"
                 >
+                  <title>{node.name}</title>
                   <rect
                     x={-node.width / 2}
                     y={-node.height / 2}
                     width={node.width}
                     height={node.height}
-                    rx="18"
-                    ry="18"
-                    strokeWidth={isCurrentGroup ? 2.8 : 1.5}
-                    className={cn(
-                      "transition-colors",
-                      isCurrentGroup
-                        ? "fill-primary/10 stroke-primary"
-                        : "fill-muted/10 stroke-border",
-                    )}
+                    rx="8"
+                    ry="8"
+                    strokeWidth={isCurrentGroup ? 1.5 : 1}
+                    className="graph-node-surface"
+                    data-selected={isCurrentGroup}
                   />
                   <line
                     x1={-node.width / 2}
@@ -757,42 +753,46 @@ export default function ChunkGraphCanvas({
                   <text
                     x={-node.width / 2 + 16}
                     y={-node.height / 2 + 24}
-                    className="fill-foreground text-[13px] font-medium"
+                    className="fill-foreground font-medium"
+                    style={{ fontSize: compact ? labelSize : 13 }}
                   >
-                    {trimGraphLabel(node.name, 34)}
+                    {trimGraphLabel(node.name, compact ? 14 : 23)}
                   </text>
                   <text
                     x={-node.width / 2 + 16}
                     y={-node.height / 2 + 42}
-                    className="fill-muted-foreground text-[10px]"
+                    className="fill-muted-foreground"
+                    style={{ fontSize: compact ? Math.min(18, 9 / renderScale) : 10 }}
                   >
-                    {`${node.chunks.length} chunks · ${node.parents.length} in · ${node.children.length} out`}
+                    {compact
+                      ? `${node.initial ? "Initial" : "Async"} · ${node.chunks.length} ${node.chunks.length === 1 ? "chunk" : "chunks"}`
+                      : `${node.chunks.length} chunks · ${node.parents.length} in · ${node.children.length} out`}
                   </text>
-                  <rect
-                    x={node.width / 2 - 68}
-                    y={-node.height / 2 + 14}
-                    width="52"
-                    height="20"
-                    rx="10"
-                    ry="10"
-                    className={cn(
-                      node.initial
-                        ? "fill-primary/15 stroke-primary/35"
-                        : "fill-muted stroke-border",
-                    )}
-                    strokeWidth="1"
-                  />
-                  <text
-                    x={node.width / 2 - 42}
-                    y={-node.height / 2 + 27}
-                    textAnchor="middle"
-                    className={cn(
-                      "text-[10px] font-medium",
-                      node.initial ? "fill-primary" : "fill-muted-foreground",
-                    )}
-                  >
-                    {node.initial ? "initial" : "async"}
-                  </text>
+                  {!compact && (
+                    <>
+                      <rect
+                        x={node.width / 2 - 68}
+                        y={-node.height / 2 + 14}
+                        width="52"
+                        height="20"
+                        rx="4"
+                        ry="4"
+                        className="fill-muted stroke-border"
+                        strokeWidth="1"
+                      />
+                      <text
+                        x={node.width / 2 - 42}
+                        y={-node.height / 2 + 27}
+                        textAnchor="middle"
+                        className={cn(
+                          "text-[10px] font-medium",
+                          node.initial ? "fill-chart-2" : "fill-muted-foreground",
+                        )}
+                      >
+                        {node.initial ? "initial" : "async"}
+                      </text>
+                    </>
+                  )}
 
                   {node.chunks.length > 0 ? (
                     node.chunks.map((chunk, index) => {
@@ -809,22 +809,27 @@ export default function ChunkGraphCanvas({
                           key={`${node.id}-${chunk.id}`}
                           transform={`translate(${-node.width / 2 + GROUP_PADDING} ${rowY})`}
                         >
+                          <title>{[chunk.name, ...chunk.files].join("\n")}</title>
                           <rect
                             x="0"
                             y="0"
                             width={node.width - GROUP_PADDING * 2}
                             height={CHUNK_ROW_HEIGHT}
-                            rx="12"
-                            ry="12"
+                            rx="5"
+                            ry="5"
                             strokeWidth={isSelectedChunk || isCurrentChunk ? 2 : 1}
-                            className={cn(
-                              "cursor-pointer transition-colors",
-                              isSelectedChunk
-                                ? "fill-primary/12 stroke-primary"
-                                : isCurrentChunk
-                                  ? "fill-primary/6 stroke-primary/40"
-                                  : "fill-background stroke-border",
-                            )}
+                            className="graph-node-surface cursor-pointer"
+                            data-selected={isSelectedChunk || isCurrentChunk}
+                            role="button"
+                            tabIndex={0}
+                            aria-label={`Inspect chunk ${chunk.name}`}
+                            aria-pressed={isSelectedChunk}
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter" || event.key === " ") {
+                                event.preventDefault();
+                                onSelectChunk?.(chunk.id);
+                              }
+                            }}
                             onPointerDown={(event) => {
                               event.stopPropagation();
                             }}
@@ -835,29 +840,32 @@ export default function ChunkGraphCanvas({
                           />
                           <text
                             x="12"
-                            y="15"
-                            className="fill-foreground text-[11px] font-medium"
+                            y={compact ? 27 : 15}
+                            className="fill-foreground font-medium"
+                            style={{ fontSize: compact ? labelSize : 11 }}
                             pointerEvents="none"
                           >
-                            {trimGraphLabel(labelFromGraphText(chunk.name), 28)}
+                            {trimGraphLabel(labelFromGraphText(chunk.name), compact ? 18 : 28)}
                           </text>
-                          <text
-                            x="12"
-                            y="29"
-                            className="fill-muted-foreground text-[10px]"
-                            pointerEvents="none"
-                          >
-                            {`${chunk.modules.length} modules${chunk.files.length > 0 ? ` · ${chunk.files[0]}` : ""}`}
-                          </text>
-                          {chunk.entry ? (
+                          {!compact && (
+                            <text
+                              x="12"
+                              y="29"
+                              className="fill-muted-foreground text-[10px]"
+                              pointerEvents="none"
+                            >
+                              {`${chunk.modules.length} modules${chunk.files.length > 0 ? ` · ${chunk.files[0]}` : ""}`}
+                            </text>
+                          )}
+                          {chunk.entry && !compact ? (
                             <>
                               <rect
                                 x={node.width - GROUP_PADDING * 2 - 56}
                                 y="9"
                                 width="44"
                                 height="20"
-                                rx="10"
-                                ry="10"
+                                rx="4"
+                                ry="4"
                                 className="fill-muted stroke-border"
                                 strokeWidth="1"
                                 pointerEvents="none"
@@ -892,7 +900,7 @@ export default function ChunkGraphCanvas({
         </svg>
       </div>
 
-      <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
+      <div className="break-all border-t px-3 py-2.5 text-[10px] leading-relaxed text-muted-foreground">
         {selectedChunk ? (
           <span>
             Selected chunk:{" "}

--- a/src/components/Dependencies/GraphControls.tsx
+++ b/src/components/Dependencies/GraphControls.tsx
@@ -1,0 +1,74 @@
+import { Minus, Plus, RotateCcw } from "lucide-react";
+import { useEffect, useState, type RefObject } from "react";
+import { Button } from "@/components/ui/button";
+
+export function useGraphRenderScale(
+  svgRef: RefObject<SVGSVGElement | null>,
+  frame: { width: number; height: number },
+  zoom: number,
+) {
+  const [fitScale, setFitScale] = useState(1);
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      if (width && height) setFitScale(Math.min(width / frame.width, height / frame.height));
+    });
+    observer.observe(svg);
+    return () => observer.disconnect();
+  }, [svgRef, frame.width, frame.height]);
+  return fitScale * zoom;
+}
+
+export default function GraphControls({
+  scale,
+  onZoom,
+  onReset,
+}: {
+  scale: number;
+  onZoom: (factor: number) => void;
+  onReset: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-0.5" role="group" aria-label="Graph controls">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-6 text-muted-foreground"
+        aria-label="Zoom out"
+        title="Zoom out"
+        onClick={() => onZoom(1 / 1.15)}
+      >
+        <Minus className="size-3" />
+      </Button>
+      <span
+        className="w-8 text-center text-[10px] tabular-nums text-muted-foreground"
+        aria-live="polite"
+      >
+        {Math.round(scale * 100)}%
+      </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-6 text-muted-foreground"
+        aria-label="Zoom in"
+        title="Zoom in"
+        onClick={() => onZoom(1.15)}
+      >
+        <Plus className="size-3" />
+      </Button>
+      <span className="mx-1 h-3 w-px bg-border" />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-6 text-muted-foreground"
+        aria-label="Reset graph"
+        title="Reset graph"
+        onClick={onReset}
+      >
+        <RotateCcw className="size-3" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/Dependencies/ModuleGraphCanvas.tsx
+++ b/src/components/Dependencies/ModuleGraphCanvas.tsx
@@ -6,13 +6,13 @@ import type {
   RspackModuleDeps,
 } from "@/lib/bundle/dependency";
 import { cn } from "@/lib/utils";
+import GraphControls from "./GraphControls";
 import {
-  buildCurvedPath,
   clampScale,
+  getGraphFrame,
   getSvgPoint,
   labelFromGraphText,
   normalizeGraphText,
-  projectPointToRect,
   trimGraphLabel,
   type Point,
   type ViewState,
@@ -88,21 +88,6 @@ function collectDependencies(module: RspackModuleDeps) {
 
 function isDynamicImportEdge(_dep: RspackDependency, kind: GraphEdge["kind"]) {
   return kind === "block";
-}
-
-function categoryClassName(category: RspackModuleCategory, isActive: boolean) {
-  if (isActive) {
-    return "fill-primary/26 stroke-primary";
-  }
-
-  switch (category) {
-    case "source":
-      return "fill-emerald-300/30 stroke-emerald-300";
-    case "dependency":
-      return "fill-sky-300/30 stroke-sky-300";
-    case "runtime":
-      return "fill-amber-300/30 stroke-amber-300";
-  }
 }
 
 function buildGraph(modules: RspackModuleDeps[]): { nodes: GraphNode[]; edges: GraphEdge[] } {
@@ -454,12 +439,12 @@ function buildLayout(
   };
 }
 
-const MODULE_EDGE_COLOR = "rgba(96, 165, 250, 0.9)";
-const MODULE_EDGE_ARROW_COLOR = "#60a5fa";
+const MODULE_EDGE_COLOR = "var(--graph-edge)";
+const MODULE_EDGE_ARROW_COLOR = "var(--graph-edge)";
 const MODULE_EDGE_MARKER_ID = "module-graph-arrow";
 
-const MODULE_NODE_WIDTH = 156;
-const MODULE_NODE_HEIGHT = 56;
+const MODULE_NODE_WIDTH = 220;
+const MODULE_NODE_HEIGHT = 76;
 
 export default function ModuleGraphCanvas({
   modules,
@@ -561,6 +546,18 @@ export default function ModuleGraphCanvas({
       window.removeEventListener("pointerup", handlePointerUp);
     };
   }, []);
+
+  const frame = useMemo(
+    () =>
+      getGraphFrame(
+        graph.nodes.map((node) => ({
+          position: layout.positions[node.id] ?? { x: 0, y: 0 },
+          width: MODULE_NODE_WIDTH,
+          height: MODULE_NODE_HEIGHT,
+        })),
+      ),
+    [graph.nodes, layout.positions],
+  );
 
   const positionedNodes = useMemo(() => {
     return graph.nodes.map((node) => ({
@@ -678,11 +675,19 @@ export default function ModuleGraphCanvas({
   };
 
   const updateScale = (factor: number) => {
-    setView((current) => ({
-      scale: clampScale(current.scale * factor),
-      panX: current.panX,
-      panY: current.panY,
-    }));
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const center = getSvgPoint(svg, rect.x + rect.width / 2, rect.y + rect.height / 2);
+    if (!center) return;
+    setView((current) => {
+      const scale = clampScale(current.scale * factor);
+      return {
+        scale,
+        panX: center.x - ((center.x - current.panX) * scale) / current.scale,
+        panY: center.y - ((center.y - current.panY) * scale) / current.scale,
+      };
+    });
   };
 
   if (graph.nodes.length === 0) {
@@ -699,54 +704,28 @@ export default function ModuleGraphCanvas({
   }
 
   return (
-    <div className={cn("rounded-lg border bg-background/70", className)}>
-      <div className="flex items-center justify-between border-b px-3 py-2">
-        <div className="text-sm font-medium">Module Graph</div>
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => updateScale(1.15)}
-            className="rounded-md border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent"
-          >
-            +
-          </button>
-          <button
-            type="button"
-            onClick={() => updateScale(0.87)}
-            className="rounded-md border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent"
-          >
-            -
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setView({ panX: 0, panY: 0, scale: 1 });
-              setNodeOverrides({});
-            }}
-            className="rounded-md border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent"
-          >
-            Reset
-          </button>
-        </div>
+    <div className={cn("overflow-hidden rounded-md border bg-card", className)}>
+      <div className="flex h-11 items-center justify-between gap-2 border-b bg-muted/40 px-3">
+        <h3 className="text-[11px] font-medium">Module graph</h3>
+        <GraphControls
+          scale={view.scale}
+          onZoom={updateScale}
+          onReset={() => {
+            setView({ panX: 0, panY: 0, scale: 1 });
+            setNodeOverrides({});
+          }}
+        />
       </div>
 
-      <div className="h-[360px] overflow-hidden">
+      <div className="graph-stage h-[340px] overflow-hidden">
         <svg
           ref={svgRef}
-          viewBox={`0 0 ${layout.width} ${layout.height}`}
-          className="h-full w-full touch-none select-none overscroll-none"
+          viewBox={`${frame.x} ${frame.y} ${frame.width} ${frame.height}`}
+          className="h-full w-full touch-none select-none overscroll-none cursor-grab active:cursor-grabbing"
+          aria-label="Module graph interactive canvas"
           onPointerDown={handleCanvasPointerDown}
         >
           <defs>
-            <pattern id="module-graph-grid" width="32" height="32" patternUnits="userSpaceOnUse">
-              <path
-                d="M 32 0 L 0 0 0 32"
-                fill="none"
-                stroke="currentColor"
-                strokeOpacity="0.08"
-                strokeWidth="1"
-              />
-            </pattern>
             <marker
               id={MODULE_EDGE_MARKER_ID}
               markerWidth="6"
@@ -761,12 +740,11 @@ export default function ModuleGraphCanvas({
           </defs>
 
           <rect
-            x="0"
-            y="0"
-            width={layout.width}
-            height={layout.height}
-            fill="url(#module-graph-grid)"
-            className="text-foreground"
+            x={frame.x}
+            y={frame.y}
+            width={frame.width}
+            height={frame.height}
+            fill="transparent"
             onPointerDown={handleCanvasPointerDown}
           />
 
@@ -776,27 +754,29 @@ export default function ModuleGraphCanvas({
               const target = nodeById.get(edge.targetId);
               if (!source || !target) return null;
 
-              const start = projectPointToRect(
-                source.position,
-                target.position,
-                MODULE_NODE_WIDTH,
-                MODULE_NODE_HEIGHT,
-                4,
-              );
-              const end = projectPointToRect(
-                target.position,
-                source.position,
-                MODULE_NODE_WIDTH,
-                MODULE_NODE_HEIGHT,
-                10,
-              );
+              const deltaX = target.position.x - source.position.x;
+              const sameColumn = Math.abs(deltaX) < MODULE_NODE_WIDTH;
+              const direction = sameColumn || deltaX < 0 ? -1 : 1;
+              // Side ports keep long edges clear of other cards in the same column.
+              const start = {
+                x: source.position.x + direction * (MODULE_NODE_WIDTH / 2 + 2),
+                y: source.position.y,
+              };
+              const end = {
+                x: target.position.x + (sameColumn ? -1 : -direction) * (MODULE_NODE_WIDTH / 2 + 8),
+                y: target.position.y,
+              };
+              const laneX = Math.min(start.x, end.x) - 28;
+              const tension = Math.max(Math.abs(end.x - start.x) / 2, 12);
+              const control1X = sameColumn ? laneX : start.x + direction * tension;
+              const control2X = sameColumn ? laneX : end.x - direction * tension;
               return (
                 <path
                   key={edge.id}
-                  d={buildCurvedPath(start, end)}
+                  d={`M ${start.x} ${start.y} C ${control1X} ${start.y}, ${control2X} ${end.y}, ${end.x} ${end.y}`}
                   fill="none"
                   stroke={MODULE_EDGE_COLOR}
-                  strokeWidth={2.3}
+                  strokeWidth={1.5}
                   strokeOpacity={1}
                   markerEnd={`url(#${MODULE_EDGE_MARKER_ID})`}
                   strokeLinecap="round"
@@ -821,29 +801,58 @@ export default function ModuleGraphCanvas({
                       onSelectModule?.(node.id);
                     }
                   }}
-                  className="cursor-grab active:cursor-grabbing"
+                  className="graph-node cursor-grab active:cursor-grabbing"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Inspect module ${node.name}`}
+                  aria-pressed={isSelected}
+                  data-graph-node={node.id}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      setSelectedNodeId(node.id);
+                      if (!node.isVirtual) onSelectModule?.(node.id);
+                    }
+                  }}
                 >
+                  <title>{node.name}</title>
                   <rect
                     x={-MODULE_NODE_WIDTH / 2}
                     y={-MODULE_NODE_HEIGHT / 2}
-                    rx="14"
-                    ry="14"
+                    rx="7"
+                    ry="7"
                     width={MODULE_NODE_WIDTH}
                     height={MODULE_NODE_HEIGHT}
-                    strokeWidth={isSelected || isActive ? 2.5 : 1.4}
+                    strokeWidth={isSelected || isActive ? 1.5 : 1}
                     strokeDasharray={node.isVirtual ? "6 5" : undefined}
-                    className={cn(
-                      "transition-colors",
-                      categoryClassName(node.category, isActive || isSelected),
-                    )}
+                    data-selected={isActive || isSelected}
+                    className="graph-node-surface"
                   />
-                  <text
-                    x="0"
-                    y="4"
-                    textAnchor="middle"
-                    className="fill-foreground text-[12px] font-medium"
-                  >
-                    {trimGraphLabel(labelFromGraphText(node.name))}
+                  <circle
+                    cx="-91"
+                    cy="-16"
+                    r="3"
+                    className={
+                      node.category === "source"
+                        ? "fill-chart-2"
+                        : node.category === "dependency"
+                          ? "fill-chart-1"
+                          : "fill-chart-3"
+                    }
+                  />
+                  <text x="-80" y="-12" className="fill-muted-foreground text-[9px]">
+                    {node.category === "dependency"
+                      ? "Package"
+                      : node.category === "runtime"
+                        ? "Runtime"
+                        : "Source"}
+                    {node.isVirtual ? " · reference" : ""}
+                  </text>
+                  <text x="-94" y="9" className="fill-foreground text-[16px] font-medium">
+                    {trimGraphLabel(labelFromGraphText(node.name), 20)}
+                  </text>
+                  <text x="-94" y="26" className="fill-muted-foreground text-[9px] font-mono">
+                    {trimGraphLabel(normalizeGraphText(node.name), 34)}
                   </text>
                 </g>
               );
@@ -852,7 +861,7 @@ export default function ModuleGraphCanvas({
         </svg>
       </div>
 
-      <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
+      <div className="break-all border-t px-3 py-2.5 text-[10px] leading-relaxed text-muted-foreground">
         {selectedNode ? (
           <span>
             Selected: <span className="font-medium text-foreground">{selectedNode.name}</span>

--- a/src/components/Dependencies/graphCanvasUtils.ts
+++ b/src/components/Dependencies/graphCanvasUtils.ts
@@ -11,6 +11,23 @@ export type ViewState = {
   scale: number;
 };
 
+export function getGraphFrame(nodes: { position: Point; width: number; height: number }[]) {
+  if (!nodes.length) return { x: 0, y: 0, width: 360, height: 240 };
+  let left = Infinity;
+  let top = Infinity;
+  let right = -Infinity;
+  let bottom = -Infinity;
+  for (const node of nodes) {
+    left = Math.min(left, node.position.x - node.width / 2);
+    right = Math.max(right, node.position.x + node.width / 2);
+    top = Math.min(top, node.position.y - node.height / 2);
+    bottom = Math.max(bottom, node.position.y + node.height / 2);
+  }
+  const width = Math.max(right - left + 80, 360);
+  const height = Math.max(bottom - top + 80, 240);
+  return { x: (left + right - width) / 2, y: (top + bottom - height) / 2, width, height };
+}
+
 export const normalizeGraphText = normalizePath;
 
 export function labelFromGraphText(name: string) {
@@ -77,7 +94,11 @@ export function buildCurvedPath(start: Point, end: Point) {
   const deltaX = end.x - start.x;
   const deltaY = end.y - start.y;
   const direction = deltaX >= 0 ? 1 : -1;
-  const horizontalTension = Math.max(Math.abs(deltaX) * 0.4, 52);
+  if (Math.abs(deltaY) > Math.abs(deltaX)) {
+    const verticalTension = deltaY * 0.45;
+    return `M ${start.x} ${start.y} C ${start.x} ${start.y + verticalTension}, ${end.x} ${end.y - verticalTension}, ${end.x} ${end.y}`;
+  }
+  const horizontalTension = Math.abs(deltaX) * 0.45;
   const verticalTension = deltaY * 0.16;
   const control1 = {
     x: start.x + direction * horizontalTension,

--- a/src/components/Dependencies/index.tsx
+++ b/src/components/Dependencies/index.tsx
@@ -1,3 +1,4 @@
+import { GitBranch, Layers, Network } from "lucide-react";
 import { useMonaco } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
 import type { ReactNode, RefObject } from "react";
@@ -66,11 +67,11 @@ function categoryLabel(category: RspackModuleCategory) {
 function categoryClassName(category: RspackModuleCategory) {
   switch (category) {
     case "source":
-      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+      return "border-border bg-muted text-chart-2";
     case "dependency":
-      return "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300";
+      return "border-border bg-muted text-chart-1";
     case "runtime":
-      return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+      return "border-border bg-muted text-chart-3";
   }
 }
 
@@ -111,7 +112,7 @@ function Tag({ className, children }: { className?: string; children: ReactNode 
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-medium",
+        "inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium",
         className,
       )}
     >
@@ -130,10 +131,14 @@ function StatCard({
   hint?: string;
 }) {
   return (
-    <div className="rounded-md border bg-background/70 p-2">
+    <div className="min-w-0 px-1 py-1">
       <div className="text-[11px] text-muted-foreground">{label}</div>
-      <div className="mt-1 text-sm font-semibold">{value}</div>
-      {hint ? <div className="mt-1 text-[10px] text-muted-foreground">{hint}</div> : null}
+      <div className="mt-1 text-lg font-medium tracking-tight tabular-nums">{value}</div>
+      {hint ? (
+        <div className="mt-1 line-clamp-2 break-all text-[10px] text-muted-foreground" title={hint}>
+          {hint}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -850,7 +855,7 @@ export default function DependencyPanel({
 
     return (
       <div className="flex min-h-full flex-col">
-        <div className="border-b p-3">
+        <div className="border-b p-4">
           <ModuleGraphCanvas
             modules={modules}
             currentModuleId={currentModule?.id ?? null}
@@ -859,7 +864,7 @@ export default function DependencyPanel({
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-2 border-b p-3">
+        <div className="grid grid-cols-2 gap-2 border-b p-4">
           <StatCard
             label="Chunks"
             value={currentChunks.length}
@@ -881,22 +886,19 @@ export default function DependencyPanel({
         </div>
 
         {!currentModule ? (
-          <div className="border-b p-3 text-sm text-muted-foreground">
-            Current file is not part of the module graph. The graph above still shows the bundled
-            module relationships; click a graph node to inspect its chunk placement and
-            dependencies.
+          <div className="border-b px-4 py-3 text-xs leading-relaxed text-muted-foreground">
+            This file is outside the module graph. Select a node to inspect its dependencies.
           </div>
         ) : null}
 
-        {inspectedModule && !isInspectingActiveFile ? (
-          <div className="border-b p-3 text-sm text-muted-foreground">
-            You are inspecting a graph-selected module. Source-range highlighting and import hover
-            sync only work when that module's file is active in the editor.
+        {currentModule && inspectedModule && !isInspectingActiveFile ? (
+          <div className="border-b px-4 py-3 text-xs leading-relaxed text-muted-foreground">
+            Open this module in the editor to see source highlights and import links.
           </div>
         ) : null}
 
         {inspectedModule && currentGroups.length > 0 ? (
-          <div className="border-b p-3">
+          <div className="border-b p-4">
             <div className="text-xs font-semibold text-muted-foreground">Module chunk groups</div>
             <div className="mt-2 flex flex-wrap gap-1">
               {currentGroups.map((group) =>
@@ -958,7 +960,7 @@ export default function DependencyPanel({
 
     return (
       <div className="flex min-h-full flex-col">
-        <div className="border-b p-3">
+        <div className="border-b p-4">
           <ChunkGraphCanvas
             chunkGroups={visibleGroups}
             chunks={visibleChunks}
@@ -971,8 +973,8 @@ export default function DependencyPanel({
         </div>
 
         {selectedChunk ? (
-          <div className="border-b p-3">
-            <div className="rounded-lg border bg-background/70 p-3">
+          <div className="border-b p-4">
+            <div className="rounded-md border bg-card p-3">
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0">
                   <div className="truncate text-sm font-medium">{selectedChunk.name}</div>
@@ -1022,17 +1024,13 @@ export default function DependencyPanel({
               ) : null}
             </div>
           </div>
-        ) : (
-          <div className="border-b p-3 text-sm text-muted-foreground">
-            Click a chunk in the graph above to inspect the modules bundled into it.
-          </div>
-        )}
+        ) : null}
 
         <div className="p-3">
           {selectedChunk ? (
-            <div className="rounded-lg border bg-background/70">
+            <div className="rounded-md border bg-card">
               <div className="border-b px-3 py-2">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-col gap-2">
                   <div className="text-xs font-semibold text-muted-foreground">
                     Chunk modules ({filteredSelectedChunkModules.length}
                     {chunkSearchQuery ? ` / ${selectedChunk.modules.length} matched` : ""})
@@ -1042,7 +1040,7 @@ export default function DependencyPanel({
                     value={chunkSearch}
                     onChange={(event) => setChunkSearch(event.target.value)}
                     placeholder="Search modules in chunk"
-                    className="h-8 rounded-md border bg-background px-3 text-xs outline-none transition-colors placeholder:text-muted-foreground focus:border-primary sm:w-56"
+                    className="h-8 w-full min-w-0 rounded-md border bg-muted/30 px-2.5 text-xs outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
                   />
                 </div>
               </div>
@@ -1069,7 +1067,9 @@ export default function DependencyPanel({
                               </Tag>
                             ) : null}
                           </div>
-                          <div className="mt-1 truncate text-xs font-medium">{module.name}</div>
+                          <div className="mt-1 break-all text-xs font-medium" title={module.name}>
+                            {module.name}
+                          </div>
                           {module.path && module.path !== module.name ? (
                             <div className="mt-1 truncate text-[11px] text-muted-foreground">
                               {module.path}
@@ -1096,49 +1096,53 @@ export default function DependencyPanel({
     <>
       <DependencyLines lines={viewMode === "module" ? lines : []} />
       <div className="flex h-full min-h-0 flex-col">
-        <div className="border-b bg-muted/30 p-2">
-          <div className="flex items-start justify-between gap-2">
-            <div>
-              <div className="text-sm font-medium">Graph Explorer</div>
-              <div className="text-[11px] text-muted-foreground">
-                {modules.length} modules · {chunks.length} chunks · {chunkGroups.length} groups
-                {currentModule ? ` · active: ${currentModule.name}` : ""}
-              </div>
-            </div>
-            {viewMode === "module" && totalDeps > 0 && isInspectingActiveFile ? (
+        <div className="workspace-panel-heading">
+          <div className="flex min-w-0 items-center gap-2">
+            <Network className="size-3.5 shrink-0 text-muted-foreground" />
+            <h2>Dependencies</h2>
+            <span className="ml-1 text-[10px] font-normal tabular-nums text-muted-foreground">
+              {modules.length}
+            </span>
+          </div>
+          {viewMode === "module" && totalDeps > 0 && isInspectingActiveFile ? (
+            <button
+              type="button"
+              onClick={handleShowAll}
+              aria-pressed={showAll}
+              className={cn(
+                "rounded px-1.5 py-1 text-[10px] font-normal transition-colors hover:bg-accent",
+                showAll ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {showAll ? "Hide links" : "Show links"}
+            </button>
+          ) : null}
+        </div>
+        <div className="flex h-9 shrink-0 items-stretch gap-5 border-b px-4">
+          {(["module", "chunk"] as GraphView[]).map((mode) => {
+            const Icon = mode === "module" ? GitBranch : Layers;
+            return (
               <button
+                key={mode}
                 type="button"
-                onClick={handleShowAll}
+                onClick={() => setViewMode(mode)}
+                aria-label={mode === "module" ? "Module Graph" : "Chunk Graph"}
+                aria-pressed={viewMode === mode}
                 className={cn(
-                  "rounded-md px-2 py-1 text-xs transition-colors",
-                  showAll
-                    ? "bg-primary text-primary-foreground"
-                    : "bg-background text-muted-foreground hover:bg-accent",
+                  "relative flex items-center gap-1.5 text-[11px] transition-colors",
+                  viewMode === mode
+                    ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-foreground/60"
+                    : "text-muted-foreground hover:text-foreground",
                 )}
               >
-                {showAll ? "Hide All" : "Show All"}
+                <Icon className="size-3" />
+                {mode === "module" ? "Modules" : "Chunks"}
+                <span className="text-[10px] text-muted-foreground">
+                  {mode === "module" ? modules.length : chunks.length}
+                </span>
               </button>
-            ) : null}
-          </div>
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <div className="inline-flex rounded-md border bg-background p-0.5">
-              {(["module", "chunk"] as GraphView[]).map((mode) => (
-                <button
-                  key={mode}
-                  type="button"
-                  onClick={() => setViewMode(mode)}
-                  className={cn(
-                    "rounded-sm px-2 py-1 text-xs font-medium transition-colors",
-                    viewMode === mode
-                      ? "bg-primary text-primary-foreground"
-                      : "text-muted-foreground hover:bg-accent",
-                  )}
-                >
-                  {mode === "module" ? "Module Graph" : "Chunk Graph"}
-                </button>
-              ))}
-            </div>
-          </div>
+            );
+          })}
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto">

--- a/src/components/Editor/CodeEditor.tsx
+++ b/src/components/Editor/CodeEditor.tsx
@@ -1,6 +1,7 @@
 import MonacoEditor from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
 import type React from "react";
+import { FileCode2 } from "lucide-react";
 import FileTabs from "@/components/Editor/FileTabs";
 import { useTheme } from "@/components/ThemeProvider";
 import { getSourceFileIdentity, type SourceFile } from "@/store/bundler";
@@ -82,7 +83,7 @@ export default function CodeEditor({
 
   if (!currentFile) {
     return (
-      <div className="flex items-center justify-center h-full text-muted-foreground">
+      <div className="flex h-full items-center justify-center px-6 text-xs text-muted-foreground">
         No file selected
       </div>
     );
@@ -90,10 +91,10 @@ export default function CodeEditor({
 
   // `path` identifies the Monaco model. Input files use an immutable identity so
   // renaming only changes the displayed filename and preserves editor history.
-  const modelPath = `rspack-playground://${readonly ? "output" : "input"}/${encodeURIComponent(getSourceFileIdentity(currentFile))}`;
+  const modelPath = `rspack-playground://${readonly ? "output" : "input"}/${encodeURIComponent(getSourceFileIdentity(currentFile).replace(/^\/+/, ""))}`;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex h-full min-w-0 flex-col" data-editor-kind={readonly ? "output" : "input"}>
       <FileTabs
         files={files}
         activeIndex={activeIndex}
@@ -110,7 +111,56 @@ export default function CodeEditor({
           path={modelPath}
           value={currentFile.text}
           language={getLanguage(currentFile.filename)}
-          theme={resolvedTheme === "dark" ? "vs-dark" : "vs"}
+          theme={resolvedTheme === "dark" ? "workspace-dark" : "workspace-light"}
+          beforeMount={(monaco) => {
+            monaco.editor.defineTheme("workspace-dark", {
+              base: "vs-dark",
+              inherit: true,
+              rules: [
+                { token: "comment", foreground: "7f848d" },
+                { token: "keyword", foreground: "b6b5d7" },
+                { token: "string", foreground: "b5c8b4" },
+                { token: "number", foreground: "d4ba8c" },
+                { token: "type.identifier", foreground: "c6cbd8" },
+              ],
+              colors: {
+                "editor.background": "#0f1011",
+                "editor.foreground": "#d0d6e0",
+                "editorLineNumber.foreground": "#4b4f56",
+                "editorLineNumber.activeForeground": "#a2a6af",
+                "editor.lineHighlightBackground": "#141516",
+                "editor.selectionBackground": "#333544",
+                "editor.inactiveSelectionBackground": "#272930",
+                "editorCursor.foreground": "#d0d6e0",
+                "editorIndentGuide.background1": "#202226",
+                "editorWidget.background": "#191a1b",
+                "editorWidget.border": "#34343a",
+                "editorSuggestWidget.background": "#191a1b",
+                "editorSuggestWidget.border": "#34343a",
+                "editorHoverWidget.background": "#191a1b",
+                "editorHoverWidget.border": "#34343a",
+              },
+            });
+            monaco.editor.defineTheme("workspace-light", {
+              base: "vs",
+              inherit: true,
+              rules: [
+                { token: "comment", foreground: "6f737c" },
+                { token: "keyword", foreground: "6c619b" },
+                { token: "string", foreground: "59775c" },
+                { token: "number", foreground: "9b7a48" },
+              ],
+              colors: {
+                "editor.background": "#ffffff",
+                "editor.foreground": "#393a40",
+                "editorLineNumber.foreground": "#babcc4",
+                "editorLineNumber.activeForeground": "#777981",
+                "editor.lineHighlightBackground": "#fafafa",
+                "editor.selectionBackground": "#e8e8f4",
+                "editorIndentGuide.background1": "#f0f0f2",
+              },
+            });
+          }}
           onChange={handleContentChange}
           onMount={(editor, monaco) => {
             const jsOptions = monaco.languages.typescript.javascriptDefaults.getCompilerOptions();
@@ -139,7 +189,13 @@ export default function CodeEditor({
           options={{
             readOnly: readonly,
             minimap: { enabled: false },
-            fontSize: 14,
+            fontSize: 13,
+            fontFamily: '"SF Mono", Menlo, Monaco, Consolas, monospace',
+            lineHeight: 22,
+            padding: { top: 18, bottom: 18 },
+            lineNumbersMinChars: 3,
+            overviewRulerBorder: false,
+            scrollbar: { verticalScrollbarSize: 7, horizontalScrollbarSize: 7 },
             lineNumbers: "on",
             roundedSelection: false,
             scrollBeyondLastLine: false,
@@ -148,6 +204,13 @@ export default function CodeEditor({
             insertSpaces: true,
           }}
         />
+      </div>
+      <div className="flex h-7 shrink-0 items-center gap-2 border-t px-3 text-[10px] text-muted-foreground">
+        <FileCode2 className="size-3 shrink-0 opacity-60" />
+        <span className="min-w-0 flex-1 truncate font-mono" title={currentFile.filename}>
+          {currentFile.filename}
+        </span>
+        <span className="shrink-0 capitalize">{getLanguage(currentFile.filename)}</span>
       </div>
     </div>
   );

--- a/src/components/Editor/FileTabs.tsx
+++ b/src/components/Editor/FileTabs.tsx
@@ -1,6 +1,6 @@
-import { Edit2, Plus, X } from "lucide-react";
+import { Edit2, FileCode2, Plus, X } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -39,6 +39,11 @@ export default function FileTabs({
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [newFileName, setNewFileName] = useState("");
+  const activeTabRef = useRef<HTMLDivElement>(null);
+  const activeFilename = files[activeIndex]?.filename;
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeIndex, activeFilename]);
 
   const handleStartEdit = (index: number, currentName: string) => {
     if (readonly) return;
@@ -72,18 +77,47 @@ export default function FileTabs({
 
   return (
     <>
-      <div className="flex h-9 items-center border-b bg-muted/50">
-        <div className="flex flex-1 overflow-x-auto scrollbar-thin">
+      <div className="flex h-9 shrink-0 items-center border-b bg-card">
+        <div
+          className="flex min-w-0 flex-1 overflow-x-auto scrollbar-thin"
+          role="tablist"
+          aria-label={readonly ? "Output files" : "Source files"}
+        >
           {files.map((file, index) => (
             <div
               key={getSourceFileIdentity(file)}
               data-filename={file.filename}
+              ref={activeIndex === index ? activeTabRef : undefined}
+              role="tab"
+              aria-selected={activeIndex === index}
+              tabIndex={activeIndex === index ? 0 : -1}
+              title={file.filename}
+              onKeyDown={(event) => {
+                if (event.target !== event.currentTarget) return;
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onFileSelect(index);
+                }
+                if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+                  event.preventDefault();
+                  const next =
+                    (index + (event.key === "ArrowRight" ? 1 : -1) + files.length) % files.length;
+                  onFileSelect(next);
+                  const tabs =
+                    event.currentTarget.parentElement?.querySelectorAll<HTMLElement>(
+                      '[role="tab"]',
+                    );
+                  tabs?.[next]?.focus();
+                }
+              }}
               className={cn(
-                "group flex h-9 flex-shrink-0 items-center space-x-1.5 border-r px-3 text-sm cursor-pointer hover:bg-accent/50 transition-colors",
-                activeIndex === index && "bg-background border-b-2 border-b-primary",
+                "group relative flex h-9 max-w-[250px] shrink-0 cursor-pointer items-center gap-2 border-r border-border/70 px-3 text-[11px] text-muted-foreground transition-colors hover:bg-muted focus-visible:outline focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-ring",
+                activeIndex === index &&
+                  "bg-muted text-foreground after:absolute after:inset-x-3 after:bottom-0 after:h-px after:bg-foreground/60",
               )}
               onClick={() => onFileSelect(index)}
             >
+              <FileCode2 className="size-3 shrink-0 opacity-60" />
               <span
                 className="min-w-0 flex-1 truncate"
                 onDoubleClick={() => handleStartEdit(index, file.filename)}
@@ -95,7 +129,8 @@ export default function FileTabs({
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="size-3.5 opacity-0 transition-opacity group-hover:opacity-100"
+                    className="size-3.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+                    aria-label={`Rename ${file.filename}`}
                     onClick={(e) => {
                       e.stopPropagation();
                       handleStartEdit(index, file.filename);
@@ -107,7 +142,8 @@ export default function FileTabs({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="size-3.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-destructive/20"
+                      className="size-3.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-destructive/20"
+                      aria-label={`Delete ${file.filename}`}
                       onClick={(e) => handleDeleteFile(e, index)}
                     >
                       <X className="size-3" />
@@ -120,7 +156,7 @@ export default function FileTabs({
         </div>
 
         {(!readonly || actions) && (
-          <div className="relative flex items-center gap-1 px-1.5">
+          <div className="relative flex shrink-0 items-center gap-1 px-1.5">
             {!readonly && (
               <Button
                 variant="ghost"
@@ -128,6 +164,7 @@ export default function FileTabs({
                 className="size-6"
                 onClick={() => setShowCreateDialog(true)}
                 title="New file"
+                aria-label="New file"
               >
                 <Plus className="size-3.5" />
               </Button>

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -1,7 +1,7 @@
 import ansis from "ansis";
 import { useAtom, useAtomValue } from "jotai";
 import { debounce } from "lodash-es";
-import { Check, Settings2, X } from "lucide-react";
+import { Check, Code2, Layers, LoaderCircle, Settings2, X } from "lucide-react";
 import type * as Monaco from "monaco-editor";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
@@ -26,6 +26,7 @@ import {
 import { activeInputFileAtom, activeOutputFileAtom, enableDependenciesAtom } from "@/store/editor";
 
 interface InputPanelProps {
+  defaultSize?: number;
   inputFiles: EditorSourceFile[];
   activeInputFile: number;
   setActiveInputFile: (index: number) => void;
@@ -38,6 +39,7 @@ interface InputPanelProps {
 }
 
 function InputPanel({
+  defaultSize = 50,
   inputFiles,
   activeInputFile,
   setActiveInputFile,
@@ -49,8 +51,21 @@ function InputPanel({
   panelRef,
 }: InputPanelProps) {
   return (
-    <Panel id="input" defaultSize={50} minSize={20} className="min-h-0">
-      <div ref={panelRef} className="flex flex-col h-full">
+    <Panel id="input" order={0} defaultSize={defaultSize} minSize={20} className="workspace-panel">
+      <div ref={panelRef} className="flex h-full flex-col">
+        <div className="workspace-panel-heading">
+          <div className="flex items-center gap-2">
+            <Code2 className="size-3.5 text-muted-foreground" />
+            <h2>Source</h2>
+            <span className="ml-1 text-[10px] font-normal tabular-nums text-muted-foreground">
+              {inputFiles.length}
+            </span>
+          </div>
+          <span className="flex items-center gap-1.5 text-[10px] font-normal text-muted-foreground">
+            <span className="size-1 rounded-full bg-chart-2" />
+            Auto build
+          </span>
+        </div>
         <div className="flex-1 min-h-0">
           <CodeEditor
             files={inputFiles}
@@ -69,6 +84,7 @@ function InputPanel({
 }
 
 interface OutputPanelProps {
+  defaultSize?: number;
   bundleResult: BundleResult | null;
   activeOutputFile: number;
   isLoadingBinding: boolean;
@@ -82,6 +98,7 @@ interface OutputPanelProps {
 }
 
 function OutputPanel({
+  defaultSize = 50,
   bundleResult,
   activeOutputFile,
   isLoadingBinding,
@@ -122,7 +139,7 @@ function OutputPanel({
         <Settings2 className="size-3.5" />
       </Button>
       {showSettings && (
-        <div className="absolute top-full right-0 z-20 mt-2 w-56 rounded-lg border bg-background p-3 shadow-lg">
+        <div className="absolute top-full right-0 z-20 mt-2 w-56 rounded-lg border bg-popover p-3 shadow-xl">
           <div className="mb-3 flex items-center justify-between">
             <div className="text-sm font-medium">Output Settings</div>
             <Button
@@ -173,8 +190,18 @@ function OutputPanel({
   );
 
   return (
-    <Panel id="output" defaultSize={50} minSize={20} className="min-h-0">
-      <div ref={panelRef} className="flex flex-col h-full relative">
+    <Panel id="output" order={1} defaultSize={defaultSize} minSize={20} className="workspace-panel">
+      <div ref={panelRef} className="relative flex h-full flex-col">
+        <div className="workspace-panel-heading">
+          <div className="flex items-center gap-2">
+            <Layers className="size-3.5 text-muted-foreground" />
+            <h2>Output</h2>
+            <span className="ml-1 text-[10px] font-normal tabular-nums text-muted-foreground">
+              {bundleResult?.output.length ?? 0}
+            </span>
+          </div>
+          <span className="text-[10px] font-normal text-muted-foreground">Read only</span>
+        </div>
         <div className="flex-1 min-h-0">
           {bundleResult ? (
             <PanelGroup id="output-group" direction="vertical" className="h-full">
@@ -196,14 +223,14 @@ function OutputPanel({
                 <>
                   <PanelResizeHandle className="h-1 bg-border hover:bg-border/80" />
                   <Panel id="output-errors" order={1} minSize={0} maxSize={33.33}>
-                    <pre className="p-2 h-full overflow-y-auto text-wrap">
+                    <pre className="h-full overflow-y-auto whitespace-pre-wrap break-words p-4 font-mono text-[11px] leading-5">
                       {bundleResult.errors.map((err) => (
-                        <div key={err} className="text-red-500">
+                        <div key={err} className="text-destructive">
                           {ansis.strip(err)}
                         </div>
                       ))}
                       {bundleResult.warnings.map((warning) => (
-                        <div key={warning} className="text-orange-300">
+                        <div key={warning} className="text-chart-3">
                           {ansis.strip(warning)}
                         </div>
                       ))}
@@ -215,8 +242,8 @@ function OutputPanel({
           ) : (
             <div className="flex items-center justify-center h-full text-muted-foreground">
               <div className="text-center">
-                <div className="text-lg mb-2">No output yet</div>
-                <div className="text-sm">Modify your code to see the bundled result</div>
+                <div className="mb-2 text-sm font-medium text-foreground">No output yet</div>
+                <div className="text-xs">Modify your code to see the bundled result</div>
               </div>
             </div>
           )}
@@ -224,8 +251,8 @@ function OutputPanel({
         {isLoadingBinding && (
           <div className="absolute inset-0 bg-background/80 flex items-center justify-center z-10">
             <div className="flex flex-col items-center gap-3">
-              <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
-              <div className="text-sm text-muted-foreground font-medium">Loading Binding...</div>
+              <LoaderCircle className="size-5 animate-spin text-muted-foreground" />
+              <div className="text-sm text-muted-foreground font-medium">Preparing compiler…</div>
             </div>
           </div>
         )}
@@ -327,27 +354,15 @@ function Editor() {
 
   const ResizeHandle = ({ isVertical }: { isVertical: boolean }) => (
     <PanelResizeHandle
-      className={`${
-        isVertical ? "h-1 bg-border hover:bg-border/80" : "w-1 bg-border hover:bg-border/80"
-      } transition-colors relative group`}
-    >
-      <div
-        className={`absolute bg-border group-hover:bg-border/80 transition-colors ${
-          isVertical ? "inset-x-0 top-1/2 h-0.5" : "inset-y-0 left-1/2 w-0.5"
-        }`}
-      />
-      <div
-        className={`absolute bg-border group-hover:bg-border/80 rounded-full opacity-0 group-hover:opacity-100 transition-opacity ${
-          isVertical
-            ? "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-8 h-1"
-            : "inset-y-0 left-1/2 -translate-x-1/2 w-1 h-8"
-        }`}
-      />
-    </PanelResizeHandle>
+      className={`relative z-10 shrink-0 bg-border transition-colors hover:bg-ring/70 focus-visible:bg-ring ${isVertical ? "h-px after:absolute after:inset-x-0 after:-inset-y-1" : "w-px after:absolute after:inset-y-0 after:-inset-x-1"}`}
+    />
   );
 
   return (
-    <div ref={editorContainerRef} className="flex h-full relative">
+    <div
+      ref={editorContainerRef}
+      className="relative flex h-full overflow-hidden rounded-lg border bg-card"
+    >
       {isMobile === undefined ? null : isMobile ? (
         /* Mobile layout (vertical) */
         <div className="flex flex-col h-full w-full">
@@ -383,6 +398,7 @@ function Editor() {
         <div className="flex h-full w-full">
           <PanelGroup id="editors-desktop" direction="horizontal" className="h-full">
             <InputPanel
+              defaultSize={enableDeps && bundleResult ? 35 : 50}
               inputFiles={inputFiles}
               activeInputFile={activeInputFile}
               setActiveInputFile={setActiveInputFile}
@@ -395,6 +411,7 @@ function Editor() {
             />
             <ResizeHandle isVertical={false} />
             <OutputPanel
+              defaultSize={enableDeps && bundleResult ? 35 : 50}
               bundleResult={bundleResult}
               activeOutputFile={activeOutputFile}
               setActiveOutputFile={setActiveOutputFile}
@@ -409,7 +426,13 @@ function Editor() {
             {enableDeps && bundleResult && (
               <>
                 <ResizeHandle isVertical={false} />
-                <Panel id="dependencies" defaultSize={25} minSize={15} className="min-h-0">
+                <Panel
+                  id="dependencies"
+                  order={2}
+                  defaultSize={30}
+                  minSize={20}
+                  className="workspace-panel"
+                >
                   <DependencyPanel
                     modules={bundleResult.modules}
                     chunks={bundleResult.chunks}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -94,7 +94,7 @@ const replLabels = {
 
 export default function Header() {
   const iconButtonClassName =
-    "size-7 rounded-md border-0 bg-transparent text-muted-foreground shadow-none hover:bg-accent/80 hover:text-foreground";
+    "size-7 rounded-md border-0 bg-transparent text-muted-foreground shadow-none hover:bg-accent hover:text-foreground sm:size-8";
 
   const [rspackVersion, setRspackVersion] = useAtom(rspackVersionAtom);
   const enabledVersions = useAtomValue(enabledRspackVersionsAtom);
@@ -176,16 +176,20 @@ export default function Header() {
   };
 
   return (
-    <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="flex h-12 items-center px-3">
-        <div className="flex max-h-full items-center space-x-2.5">
-          <Logo className="h-8 w-8" />
-          <h1 className="text-base font-semibold">Rspack Playground</h1>
+    <header className="shrink-0 bg-background">
+      <div className="flex min-h-14 flex-wrap items-center gap-x-3 gap-y-2 px-3 py-3 sm:px-5">
+        <div className="flex shrink-0 items-center gap-2.5">
+          <Logo className="size-6" />
+          <span className="text-[13px] font-semibold tracking-tight">Rspack</span>
+          <span className="mx-1 text-sm text-muted-foreground/40" aria-hidden="true">
+            /
+          </span>
+          <h1 className="text-[13px] font-medium text-muted-foreground">Playground</h1>
         </div>
-        <div className="flex-1" />
-        <div className="flex items-center">
-          <div className="flex items-center gap-2 pr-3">
-            <div className="flex items-center space-x-1.5 text-[13px] text-muted-foreground">
+        <div className="hidden flex-1 sm:block" />
+        <div className="ml-auto flex min-w-0 items-center">
+          <div className="flex items-center gap-3 pr-2 sm:pr-3">
+            <div className="hidden items-center gap-1.5 text-[11px] tabular-nums text-muted-foreground lg:flex">
               <Clock className="h-3.5 w-3.5" />
               <span>
                 {isBundling
@@ -204,7 +208,7 @@ export default function Header() {
             >
               <SelectTrigger
                 size="sm"
-                className="h-7 w-[188px] border bg-background/80 px-2.5 text-xs shadow-none hover:bg-background"
+                className="h-7 w-[88px] rounded-md border-border bg-card px-2 text-[11px] shadow-none hover:bg-accent sm:w-[148px]"
                 title={`Switch Rspack version (current: ${selectedVersionDisplay.fullLabel})`}
                 aria-label={`Switch Rspack version, current ${selectedVersionDisplay.fullLabel}`}
               >
@@ -266,7 +270,7 @@ export default function Header() {
             </Select>
           </div>
           <div className="h-4 w-px bg-border" />
-          <div className="flex items-center gap-0.5 px-3">
+          <div className="flex items-center gap-0.5 px-1.5 sm:gap-1 sm:px-3">
             <Button
               variant="ghost"
               size="icon"
@@ -353,7 +357,7 @@ export default function Header() {
             <Preview />
           </div>
           <div className="h-4 w-px bg-border" />
-          <div className="flex items-center gap-0.5 pl-3">
+          <div className="flex items-center gap-0.5 pl-1.5 sm:pl-3">
             <ModeToggle />
             <Button variant="ghost" size="icon" className={iconButtonClassName} asChild>
               <a

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -17,7 +17,7 @@ export function ModeToggle() {
         <Button
           variant="ghost"
           size="icon"
-          className="size-7 rounded-md border-0 bg-transparent text-muted-foreground shadow-none hover:bg-accent/80 hover:text-foreground"
+          className="relative size-7 rounded-md border-0 bg-transparent text-muted-foreground shadow-none hover:bg-accent/80 hover:text-foreground sm:size-8"
           title="Change theme"
           aria-label="Change theme"
         >

--- a/src/components/Preview/index.tsx
+++ b/src/components/Preview/index.tsx
@@ -12,6 +12,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { bundleResultAtom, type SourceFile } from "@/store/bundler";
+import { initializePreviewWorkers } from "./initializeWorkers";
 
 interface PreviewFrameProps {
   files: SourceFile[];
@@ -23,7 +24,8 @@ function PreviewFrame(props: PreviewFrameProps) {
   const entry = getEntry(files);
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
+    const { signal } = controller;
 
     async function disposeServiceWorker() {
       const registrations = await navigator.serviceWorker.getRegistrations();
@@ -37,43 +39,13 @@ function PreviewFrame(props: PreviewFrameProps) {
 
     async function registerServiceWorker() {
       await disposeServiceWorker();
-      if (cancelled) return;
+      if (signal.aborted) return;
 
       const registration = await navigator.serviceWorker.register("/preview/service-worker.js", {
         scope: "/preview/",
       });
 
-      function init(sw: ServiceWorker) {
-        if (cancelled) return;
-        sw.postMessage({
-          type: "init",
-          files,
-          scope: "/preview/",
-        });
-      }
-
-      function waitToInit(sw: ServiceWorker) {
-        return new Promise<void>((resolve, reject) => {
-          const handleStateChange = () => {
-            if (sw.state === "activated") {
-              sw.removeEventListener("statechange", handleStateChange);
-              init(sw);
-              resolve();
-            } else if (sw.state === "redundant") {
-              sw.removeEventListener("statechange", handleStateChange);
-              reject(new Error("The preview worker could not be activated."));
-            }
-          };
-          sw.addEventListener("statechange", handleStateChange);
-          handleStateChange();
-        });
-      }
-
-      const worker = registration.active ?? registration.installing ?? registration.waiting;
-      if (!worker) {
-        throw new Error("No preview worker is available.");
-      }
-      await waitToInit(worker);
+      await initializePreviewWorkers(registration, files, signal);
     }
 
     const iframe = iframeRef.current;
@@ -81,12 +53,12 @@ function PreviewFrame(props: PreviewFrameProps) {
       const iframeWindow = iframe.contentWindow;
       registerServiceWorker()
         .then(() => {
-          if (cancelled) return;
+          if (signal.aborted) return;
           const name = entry.filename.startsWith("/") ? entry.filename.slice(1) : entry.filename;
           iframeWindow.location = `/preview/${name}`;
         })
         .catch((error: unknown) => {
-          if (!cancelled) {
+          if (!signal.aborted) {
             toast.error("Unable to start preview", {
               description: error instanceof Error ? error.message : "Please try again.",
             });
@@ -95,7 +67,7 @@ function PreviewFrame(props: PreviewFrameProps) {
     }
 
     return () => {
-      cancelled = true;
+      controller.abort();
       disposeServiceWorker();
     };
   }, [files, entry]);

--- a/src/components/Preview/index.tsx
+++ b/src/components/Preview/index.tsx
@@ -1,10 +1,12 @@
 import { useAtomValue } from "jotai";
-import { Play } from "lucide-react";
+import { Play, X } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogClose,
   DialogDescription,
   DialogTitle,
   DialogTrigger,
@@ -21,19 +23,28 @@ function PreviewFrame(props: PreviewFrameProps) {
   const entry = getEntry(files);
 
   useEffect(() => {
+    let cancelled = false;
+
     async function disposeServiceWorker() {
       const registrations = await navigator.serviceWorker.getRegistrations();
-      await Promise.all(registrations.map((registration) => registration.unregister()));
+      const previewScope = new URL("/preview/", window.location.href).href;
+      await Promise.all(
+        registrations
+          .filter((registration) => registration.scope === previewScope)
+          .map((registration) => registration.unregister()),
+      );
     }
 
     async function registerServiceWorker() {
       await disposeServiceWorker();
+      if (cancelled) return;
 
       const registration = await navigator.serviceWorker.register("/preview/service-worker.js", {
         scope: "/preview/",
       });
 
       function init(sw: ServiceWorker) {
+        if (cancelled) return;
         sw.postMessage({
           type: "init",
           files,
@@ -42,42 +53,61 @@ function PreviewFrame(props: PreviewFrameProps) {
       }
 
       function waitToInit(sw: ServiceWorker) {
-        sw.addEventListener("statechange", () => {
-          if (sw.state === "activated") {
-            init(sw);
-          }
+        return new Promise<void>((resolve, reject) => {
+          const handleStateChange = () => {
+            if (sw.state === "activated") {
+              sw.removeEventListener("statechange", handleStateChange);
+              init(sw);
+              resolve();
+            } else if (sw.state === "redundant") {
+              sw.removeEventListener("statechange", handleStateChange);
+              reject(new Error("The preview worker could not be activated."));
+            }
+          };
+          sw.addEventListener("statechange", handleStateChange);
+          handleStateChange();
         });
       }
 
-      if (registration.active) {
-        init(registration.active);
-      } else if (registration.installing) {
-        waitToInit(registration.installing);
+      const worker = registration.active ?? registration.installing ?? registration.waiting;
+      if (!worker) {
+        throw new Error("No preview worker is available.");
       }
-
-      registration.addEventListener("updatefound", () => {
-        const sw = registration.installing;
-        if (sw) {
-          waitToInit(sw);
-        }
-      });
+      await waitToInit(worker);
     }
 
     const iframe = iframeRef.current;
     if (iframe?.contentWindow && entry?.filename) {
       const iframeWindow = iframe.contentWindow;
-      registerServiceWorker().then(() => {
-        const name = entry.filename.startsWith("/") ? entry.filename.slice(1) : entry.filename;
-        iframeWindow.location = `/preview/${name}`;
-      });
+      registerServiceWorker()
+        .then(() => {
+          if (cancelled) return;
+          const name = entry.filename.startsWith("/") ? entry.filename.slice(1) : entry.filename;
+          iframeWindow.location = `/preview/${name}`;
+        })
+        .catch((error: unknown) => {
+          if (!cancelled) {
+            toast.error("Unable to start preview", {
+              description: error instanceof Error ? error.message : "Please try again.",
+            });
+          }
+        });
     }
 
     return () => {
+      cancelled = true;
       disposeServiceWorker();
     };
   }, [files, entry]);
 
-  return <iframe className="w-full h-full border-none" src="/preview" ref={iframeRef} />;
+  return (
+    <iframe
+      title="Project preview"
+      className="h-full w-full border-none bg-white"
+      src="about:blank"
+      ref={iframeRef}
+    />
+  );
 }
 
 function Preview() {
@@ -89,21 +119,35 @@ function Preview() {
     <Dialog>
       <DialogTrigger disabled={disabled} asChild>
         <Button
-          variant="ghost"
-          size="icon"
-          className="size-7 rounded-md border-0 bg-transparent text-muted-foreground shadow-none hover:bg-accent/80 hover:text-foreground"
+          variant="default"
+          size="sm"
+          className="ml-1 h-7 gap-1.5 rounded-md px-2 text-[11px] shadow-none sm:px-2.5"
           disabled={disabled}
           title="Open preview"
           aria-label="Open preview"
         >
           <Play className="h-3.5 w-3.5" />
-          <span className="sr-only">Preview</span>
+          <span className="hidden sm:inline">Preview</span>
         </Button>
       </DialogTrigger>
-      <DialogContent showCloseButton={false} className="max-w-full! w-9/12! h-8/12!">
-        <DialogTitle className="hidden"></DialogTitle>
-        <DialogDescription className="hidden"></DialogDescription>
-        <PreviewFrame files={bundleResult?.output || []} />
+      <DialogContent
+        showCloseButton={false}
+        className="flex h-[80dvh] w-[calc(100vw-2rem)] max-w-6xl flex-col gap-0 overflow-hidden rounded-lg p-0 sm:max-w-6xl"
+      >
+        <div className="flex h-12 shrink-0 items-center gap-3 border-b px-4">
+          <DialogTitle className="text-xs font-medium">Preview</DialogTitle>
+          <DialogDescription className="min-w-0 flex-1 truncate font-mono text-[11px]">
+            {entry?.filename}
+          </DialogDescription>
+          <DialogClose asChild>
+            <Button variant="ghost" size="icon" className="size-6" aria-label="Close preview">
+              <X className="size-3.5" />
+            </Button>
+          </DialogClose>
+        </div>
+        <div className="min-h-0 flex-1">
+          <PreviewFrame files={bundleResult?.output || []} />
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/Preview/initializeWorkers.ts
+++ b/src/components/Preview/initializeWorkers.ts
@@ -1,0 +1,72 @@
+import type { SourceFile } from "@/store/bundler";
+
+export function initializePreviewWorkers(
+  registration: ServiceWorkerRegistration,
+  files: SourceFile[],
+  signal: AbortSignal,
+): Promise<void> {
+  const initialized = new WeakMap<ServiceWorker, Promise<void>>();
+
+  function waitToInit(worker: ServiceWorker): Promise<void> {
+    const existing = initialized.get(worker);
+    if (existing) return existing;
+
+    const ready = new Promise<void>((resolve, reject) => {
+      function cleanup() {
+        worker.removeEventListener("statechange", handleStateChange);
+        signal.removeEventListener("abort", handleAbort);
+      }
+
+      function handleAbort() {
+        cleanup();
+        reject(new DOMException("The preview was closed.", "AbortError"));
+      }
+
+      function handleStateChange() {
+        if (signal.aborted) {
+          handleAbort();
+        } else if (worker.state === "activated") {
+          cleanup();
+          try {
+            worker.postMessage({ type: "init", files, scope: "/preview/" });
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        } else if (worker.state === "redundant") {
+          cleanup();
+          reject(new Error("The preview worker could not be activated."));
+        }
+      }
+
+      worker.addEventListener("statechange", handleStateChange);
+      signal.addEventListener("abort", handleAbort, { once: true });
+      handleStateChange();
+    });
+    initialized.set(worker, ready);
+    return ready;
+  }
+
+  function handleUpdateFound() {
+    for (const worker of [registration.active, registration.installing, registration.waiting]) {
+      if (worker) {
+        // A failed replacement must not interrupt a preview served by the active worker.
+        void waitToInit(worker).catch(() => {});
+      }
+    }
+  }
+
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("The preview was closed.", "AbortError"));
+  }
+
+  const worker = registration.active ?? registration.installing ?? registration.waiting;
+  if (!worker) {
+    return Promise.reject(new Error("No preview worker is available."));
+  }
+
+  registration.addEventListener("updatefound", handleUpdateFound, { signal });
+  const ready = waitToInit(worker);
+  handleUpdateFound();
+  return ready;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,77 +4,88 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  color-scheme: light;
+  --background: #f7f7f8;
+  --foreground: #202124;
+  --card: #ffffff;
+  --card-foreground: #202124;
+  --popover: #ffffff;
+  --popover-foreground: #202124;
+  --primary: #292a2e;
+  --primary-foreground: #ffffff;
+  --secondary: #eeeef0;
+  --secondary-foreground: #393a40;
+  --muted: #f2f2f4;
+  --muted-foreground: #6b6d75;
+  --accent: #ebebee;
+  --accent-foreground: #202124;
+  --destructive: #cd555d;
+  --destructive-foreground: #ffffff;
+  --border: #e4e4e7;
+  --input: #dedee2;
+  --ring: #5e6ad2;
+  --chart-1: #5660bf;
+  --chart-2: #49725f;
+  --chart-3: #84652f;
+  --chart-4: #686d7a;
+  --chart-5: #975e68;
+  --radius: 0.5rem;
+  --sidebar: #f9f9fa;
+  --sidebar-foreground: #393a40;
+  --sidebar-primary: #5e6ad2;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #ededf0;
+  --sidebar-accent-foreground: #202124;
+  --sidebar-border: #e4e4e7;
+  --sidebar-ring: #5e6ad2;
+  --graph-node: #ffffff;
+  --graph-node-selected: #f0f0fa;
+  --graph-node-border: #cfcfd5;
+  --graph-edge: #a0a3ae;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.145 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.145 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
-  --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.269 0 0);
-  --sidebar-ring: oklch(0.439 0 0);
+  color-scheme: dark;
+  --background: #08090a;
+  --foreground: #f7f8f8;
+  --card: #0f1011;
+  --card-foreground: #d0d6e0;
+  --popover: #191a1b;
+  --popover-foreground: #e6e7e9;
+  --primary: #e6e7e9;
+  --primary-foreground: #101112;
+  --secondary: #232326;
+  --secondary-foreground: #d0d6e0;
+  --muted: #141516;
+  --muted-foreground: #8a8f98;
+  --accent: #232326;
+  --accent-foreground: #f7f8f8;
+  --destructive: #df777e;
+  --destructive-foreground: #101112;
+  --border: #23252a;
+  --input: #34343a;
+  --ring: #7c86e3;
+  --chart-1: #7c86e3;
+  --chart-2: #8aaf9c;
+  --chart-3: #c6ab79;
+  --chart-4: #8a8f98;
+  --chart-5: #b68b92;
+  --sidebar: #101112;
+  --sidebar-foreground: #d0d6e0;
+  --sidebar-primary: #7c86e3;
+  --sidebar-primary-foreground: #f7f8f8;
+  --sidebar-accent: #191a1b;
+  --sidebar-accent-foreground: #f7f8f8;
+  --sidebar-border: #23252a;
+  --sidebar-ring: #7c86e3;
+  --graph-node: #191a1b;
+  --graph-node-selected: #20212e;
+  --graph-node-border: #34343a;
+  --graph-edge: #62666d;
 }
 
 @theme inline {
+  --font-sans: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -119,7 +130,9 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
   }
 }
 
@@ -137,12 +150,12 @@
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb {
-  background-color: hsl(var(--muted-foreground) / 0.3);
+  background-color: color-mix(in srgb, var(--muted-foreground) 25%, transparent);
   border-radius: 3px;
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-  background-color: hsl(var(--muted-foreground) / 0.5);
+  background-color: color-mix(in srgb, var(--muted-foreground) 45%, transparent);
 }
 
 /* Segment background colors for sourcemap visualization */
@@ -208,4 +221,80 @@
 
 .segment-bg-15 {
   background-color: rgba(142, 68, 173, 0.25) !important;
+}
+
+/* Shared workspace surfaces and graph styling. */
+.workspace-panel {
+  min-width: 0;
+  min-height: 0;
+  background: var(--card);
+}
+
+.workspace-panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  height: 43px;
+  flex-shrink: 0;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  color: var(--card-foreground);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.graph-node-surface {
+  fill: var(--graph-node);
+  stroke: var(--graph-node-border);
+  transition:
+    fill 150ms,
+    stroke 150ms;
+}
+
+.graph-node-surface[data-selected="true"] {
+  fill: var(--graph-node-selected);
+  stroke: var(--ring);
+}
+
+.graph-node:hover > .graph-node-surface,
+.graph-node:focus-visible > .graph-node-surface {
+  stroke: var(--muted-foreground);
+}
+
+.graph-node:focus-visible {
+  outline: none;
+}
+
+.graph-node:focus-visible > .graph-node-surface {
+  stroke: var(--ring);
+  stroke-width: 2;
+}
+
+.graph-stage {
+  background: var(--card);
+  background-image: radial-gradient(var(--border) 0.75px, transparent 0.75px);
+  background-size: 20px 20px;
+}
+
+[data-slot="dialog-content"],
+[data-slot="alert-dialog-content"] {
+  background: var(--popover);
+  box-shadow:
+    0 24px 80px #00000030,
+    0 0 0 1px #ffffff03;
+}
+
+[data-slot="dropdown-menu-content"],
+[data-slot="select-content"] {
+  box-shadow: 0 8px 30px #00000024;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/tests/preview-workers.test.mjs
+++ b/tests/preview-workers.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { getEventListeners } from "node:events";
+import { test } from "node:test";
+import { setImmediate } from "node:timers/promises";
+import { initializePreviewWorkers } from "../src/components/Preview/initializeWorkers.ts";
+
+class Worker extends EventTarget {
+  messages = [];
+
+  constructor(state) {
+    super();
+    this.state = state;
+  }
+
+  postMessage(message) {
+    this.messages.push(message);
+  }
+
+  transition(state) {
+    this.state = state;
+    this.dispatchEvent(new Event("statechange"));
+  }
+}
+
+class Registration extends EventTarget {
+  active = null;
+  installing = null;
+  waiting = null;
+
+  constructor(workers) {
+    super();
+    Object.assign(this, workers);
+  }
+}
+
+const files = [{ filename: "/dist/index.html", text: "<h1>Preview</h1>" }];
+const initMessage = { type: "init", files, scope: "/preview/" };
+
+test("the first preview waits for activation before receiving its files", async (t) => {
+  const worker = new Worker("installing");
+  const registration = new Registration({ installing: worker });
+  const controller = new AbortController();
+  t.after(() => controller.abort());
+  let ready = false;
+  const startup = initializePreviewWorkers(registration, files, controller.signal).then(() => {
+    ready = true;
+  });
+
+  worker.transition("installed");
+  worker.transition("activating");
+  await Promise.resolve();
+  assert.equal(ready, false);
+  assert.deepEqual(worker.messages, []);
+
+  worker.transition("activated");
+  await startup;
+  assert.deepEqual(worker.messages, [initMessage]);
+  assert.equal(getEventListeners(worker, "statechange").length, 0);
+});
+
+for (const slot of ["installing", "waiting"]) {
+  test(`an active worker does not hide an existing ${slot} replacement`, async (t) => {
+    const active = new Worker("activated");
+    const replacement = new Worker(slot === "installing" ? "installing" : "installed");
+    const registration = new Registration({ active, [slot]: replacement });
+    const controller = new AbortController();
+    t.after(() => controller.abort());
+
+    await initializePreviewWorkers(registration, files, controller.signal);
+    assert.deepEqual(active.messages, [initMessage]);
+    assert.deepEqual(replacement.messages, []);
+
+    replacement.transition("activated");
+    assert.deepEqual(replacement.messages, [initMessage]);
+  });
+}
+
+test("later updates are initialized once even when updatefound repeats", async (t) => {
+  const active = new Worker("activated");
+  const registration = new Registration({ active });
+  const controller = new AbortController();
+  t.after(() => controller.abort());
+  await initializePreviewWorkers(registration, files, controller.signal);
+
+  for (let update = 0; update < 2; update++) {
+    const replacement = new Worker("installing");
+    registration.installing = replacement;
+    registration.dispatchEvent(new Event("updatefound"));
+    registration.dispatchEvent(new Event("updatefound"));
+    assert.equal(getEventListeners(replacement, "statechange").length, 1);
+
+    replacement.transition("activated");
+    registration.active = replacement;
+    registration.installing = null;
+    registration.dispatchEvent(new Event("updatefound"));
+    assert.deepEqual(replacement.messages, [initMessage]);
+  }
+  assert.deepEqual(active.messages, [initMessage]);
+});
+
+test("closing a ready preview removes observers and prevents stale initialization", async () => {
+  const active = new Worker("activated");
+  const replacement = new Worker("installing");
+  const registration = new Registration({ active, installing: replacement });
+  const controller = new AbortController();
+  await initializePreviewWorkers(registration, files, controller.signal);
+
+  controller.abort();
+  assert.equal(getEventListeners(registration, "updatefound").length, 0);
+  assert.equal(getEventListeners(replacement, "statechange").length, 0);
+  replacement.transition("activated");
+  assert.deepEqual(replacement.messages, []);
+
+  const later = new Worker("activated");
+  registration.installing = later;
+  registration.dispatchEvent(new Event("updatefound"));
+  assert.deepEqual(later.messages, []);
+});
+
+test("closing during the first installation cancels readiness and removes listeners", async () => {
+  const worker = new Worker("installing");
+  const registration = new Registration({ installing: worker });
+  const controller = new AbortController();
+  const startup = initializePreviewWorkers(registration, files, controller.signal);
+
+  controller.abort();
+  await assert.rejects(startup, { name: "AbortError" });
+  assert.equal(getEventListeners(worker, "statechange").length, 0);
+  assert.equal(getEventListeners(registration, "updatefound").length, 0);
+  worker.transition("activated");
+  assert.deepEqual(worker.messages, []);
+});
+
+test("a failed first installation rejects readiness", async (t) => {
+  const worker = new Worker("installing");
+  const registration = new Registration({ installing: worker });
+  const controller = new AbortController();
+  t.after(() => controller.abort());
+  const startup = initializePreviewWorkers(registration, files, controller.signal);
+
+  worker.transition("redundant");
+  await assert.rejects(startup, /could not be activated/);
+  assert.equal(getEventListeners(worker, "statechange").length, 0);
+  assert.deepEqual(worker.messages, []);
+});
+
+test("a failed replacement leaves the active preview initialized", async (t) => {
+  const active = new Worker("activated");
+  const replacement = new Worker("installing");
+  const registration = new Registration({ active, installing: replacement });
+  const controller = new AbortController();
+  t.after(() => controller.abort());
+
+  await initializePreviewWorkers(registration, files, controller.signal);
+  replacement.transition("redundant");
+  await setImmediate();
+  assert.deepEqual(active.messages, [initMessage]);
+  assert.deepEqual(replacement.messages, []);
+  assert.equal(getEventListeners(replacement, "statechange").length, 0);
+});


### PR DESCRIPTION
The editor, graphs and preview now share a compact workspace inspired by Linear, with a dark default theme, matching Monaco colors, consistent dividers and a neutral light theme. Saved theme preferences are respected.

- Align the source, output and dependency panels; refine file tabs, toolbar controls, empty states and the preview dialog for desktop and narrow screens.
- Frame graphs around their actual node bounds, including negative coordinates; route module connections around cards and share zoom/reset controls. Add keyboard navigation and accessible names for file tabs and graph nodes.
- Keep chunk names readable when the graph is scaled down, and retain full paths in tooltips and inspection details.
- Wait for the preview worker to activate before loading the compiled page. A fresh preview starts from a blank iframe instead of occasionally rendering the playground itself. Active, installing and waiting workers receive initialization when activated, and later replacements are observed through `updatefound`. Closing the preview cancels pending initialization and removes listeners. Cleanup only unregisters workers in the preview scope, and obsolete startup callbacks do not navigate a closed preview.

Validation:

- `pnpm check`
- `pnpm test`: 8 worker lifecycle regressions covering first activation, existing and future replacements, repeated updates, cancellation and failed installation; also runs in CI.
- `pnpm exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm build`
- `git diff --check`
- Browser checks: light/dark themes, file keyboard navigation, module/chunk selection, graph zoom/drag/reset, repeated fresh preview opens, and the 320px layout and preview dialog.
- No browser warnings or errors in the final validation run.
